### PR TITLE
merge bugfix/fix-focus-stealing-text-input into dev

### DIFF
--- a/src/builders/buildBlockMode.js
+++ b/src/builders/buildBlockMode.js
@@ -1,4 +1,4 @@
-import { Events, getFocusManager, inject, serialization, svgResize } from 'blockly'
+import { Events, getFocusManager, inject, serialization, svgResize, setParentContainer } from 'blockly'
 import { pythonGenerator } from 'blockly/python'
 import { button, code, div, on, pre, tag } from 'ellipsi'
 
@@ -31,6 +31,13 @@ export default (toolbox) => {
     )
 
     codePreview.dom.id = 'code-preview'
+
+    setParentContainer(BlockEditor); // fixes Blockly blocks stealing focus from text inputs and the right click context menu
+
+    setTimeout(() => {
+        const headerHeight = document.querySelector('header').getBoundingClientRect().height;
+        document.querySelector('.blocklyWidgetDiv').style.marginTop = `-${headerHeight}px`;
+    }, 0); // adds a offset to the blockly widgets to account for the header height
 
     const workspace = inject(BlocklyCanvas, {
         toolbox: toolbox,
@@ -88,13 +95,6 @@ export default (toolbox) => {
         loadState()
     })
     resizeObserver.observe(BlockEditor)
-
-    // TODO: for debug only
-    const focusManager = getFocusManager()
-    BlocklyCanvas.addEventListener("click", () => {
-        const node = focusManager.getFocusedNode()
-        console.log(node)
-    })
 
     const saveCode = (ProjectNameInput) => {
         const projectName = ProjectNameInput?.value || 'proto'

--- a/src/helpers/codeMirrorHelper.js
+++ b/src/helpers/codeMirrorHelper.js
@@ -4,6 +4,7 @@ import {
     closeBracketsKeymap,
     completeFromList,
     completionKeymap,
+    acceptCompletion,
 } from '@codemirror/autocomplete'
 import {
     defaultKeymap,
@@ -139,6 +140,7 @@ export const newView = (
         highlightActiveLine(),
         highlightSelectionMatches(),
         keymap.of([
+            { key: "Tab", run: acceptCompletion },
             ...closeBracketsKeymap,
             ...defaultKeymap,
             ...searchKeymap,


### PR DESCRIPTION
- fixed the text input focus being stolen
- fixed the context menu not appearing on right click
- added tab key to accept auto completion on codemirror