### PR TITLE
Fix header grid placement

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -147,6 +147,10 @@
             / 1fr;
     }
 
+    header {
+        grid-area: head;
+    }
+
     nav {
         padding: 12px 8px;
         background: var(--secondary-grey);
@@ -202,11 +206,16 @@
     }
 
     footer {
+        grid-area: foot;
         text-align: center;
         background-color: var(--secondary-grey);
         color: var(--bg);
         padding: 8px;
         font-size: 0.7rem;
+    }
+
+    #editor-container {
+        grid-area: edit;
     }
 }
 


### PR DESCRIPTION
Some devices show this blank space on both block mode and code mode this fixes that 
<img width="2547" height="1220" alt="image" src="https://github.com/user-attachments/assets/18cdf6dc-3ab0-4a6f-acc7-93de9a1f285c" />
<img width="2555" height="1276" alt="image" src="https://github.com/user-attachments/assets/64cb61a6-7090-4d9d-9e82-efc5a43a75c0" />
<img width="2553" height="1277" alt="image" src="https://github.com/user-attachments/assets/2a3292b3-b10c-47a1-bbfd-1520d4826ee2" />
